### PR TITLE
fix: resolve GitHub Actions release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
       - name: Checkout code
@@ -48,12 +50,11 @@ jobs:
       
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: v${{ env.VERSION }}
-          release_name: Release v${{ env.VERSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: v${{ env.VERSION }}
+          name: Release v${{ env.VERSION }}
           body: |
             ## What's Changed
             ${{ inputs.release_notes }}
@@ -73,16 +74,7 @@ jobs:
             5. Click "Load unpacked" and select the extracted folder
           draft: false
           prerelease: false
-      
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ env.ZIP_FILE }}
-          asset_name: tab-position-options-fork-v${{ env.VERSION }}.zip
-          asset_content_type: application/zip
+          artifacts: ${{ env.ZIP_FILE }}
       
       - name: Upload to Chrome Web Store (Draft)
         uses: mnao305/chrome-extension-upload@v5.0.0
@@ -98,7 +90,7 @@ jobs:
         run: |
           echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
           echo "- Version: v${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
-          echo "- GitHub Release: [v${{ env.VERSION }}](${{ steps.create_release.outputs.html_url }})" >> $GITHUB_STEP_SUMMARY
+          echo "- GitHub Release: [v${{ env.VERSION }}](https://github.com/${{ github.repository }}/releases/tag/v${{ env.VERSION }})" >> $GITHUB_STEP_SUMMARY
           echo "- Chrome Web Store: [Draft uploaded](https://chrome.google.com/webstore/devconsole)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Next Steps" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 関連URL

- https://github.com/proshunsuke/tab-position-options-fork/actions/runs/16408929779/job/46359821783

## 概要

- GitHub Actionsのリリースワークフローで発生した権限エラーを修正
- 「Resource not accessible by integration」エラーの解決

## 変更内容

### 1. 権限の追加
```yaml
permissions:
  contents: write
```
- リリース作成に必要な権限を明示的に付与

### 2. 非推奨アクションの置き換え
- `actions/create-release@v1` → `ncipollo/release-action@v1`に変更
- より安定した新しいアクションを使用
- メンテナンスが継続されているアクション

### 3. アセットアップロードの簡略化
- 別々のステップではなく、`artifacts`パラメータで一括アップロード
- ワークフローの簡潔化

### 4. サマリー出力の修正
- GitHub Release URLを確実に生成するよう修正

## チェック項目

- [x] Revert可能