### PR TITLE
Add "New Tab Background" checkbox option

### DIFF
--- a/e2e/specs/browser-startup-tab-order.spec.ts
+++ b/e2e/specs/browser-startup-tab-order.spec.ts
@@ -45,7 +45,7 @@ test.describe("Browser Startup Tab Order", () => {
   }) => {
     // "Always first" 設定を適用
     await setExtensionSettings(context, {
-      newTab: { position: "first" },
+      newTab: { position: "first", background: false },
     });
 
     // Service Worker内でセッション復元をシミュレート
@@ -112,7 +112,7 @@ test.describe("Browser Startup Tab Order", () => {
   }) => {
     // "Always last" 設定を適用
     await setExtensionSettings(context, {
-      newTab: { position: "last" },
+      newTab: { position: "last", background: false },
     });
 
     // Service Worker内でセッション復元をシミュレート
@@ -193,7 +193,7 @@ test.describe("Browser Startup Tab Order", () => {
 
     // "Always first" 設定
     await setExtensionSettings(context, {
-      newTab: { position: "first" },
+      newTab: { position: "first", background: false },
     });
 
     // ブラウザ起動をシミュレート
@@ -258,7 +258,7 @@ test.describe("Browser Startup Tab Order", () => {
   }) => {
     // "Right of current tab" 設定
     await setExtensionSettings(context, {
-      newTab: { position: "right" },
+      newTab: { position: "right", background: false },
     });
 
     // セッション復元を開始

--- a/e2e/specs/new-tab-background.spec.ts
+++ b/e2e/specs/new-tab-background.spec.ts
@@ -1,0 +1,169 @@
+import { expect, test } from "../fixtures";
+import { createTabViaServiceWorker, getTabState, setExtensionSettings } from "../utils/helpers";
+
+test.describe("New Tab Background", () => {
+  test("should display the checkbox in options page", async ({ page, extensionId }) => {
+    await page.goto(`chrome-extension://${extensionId}/options.html`);
+
+    // チェックボックスが存在することを確認
+    const checkbox = page.locator('input[type="checkbox"]').first();
+    await expect(checkbox).toBeVisible();
+
+    // ラベルテキストを確認
+    const label = page.locator("text=New Tab Background");
+    await expect(label).toBeVisible();
+  });
+
+  test("should save and load checkbox state", async ({ page, extensionId }) => {
+    await page.goto(`chrome-extension://${extensionId}/options.html`);
+
+    const checkbox = page.locator('input[type="checkbox"]').first();
+    const saveButton = page.locator('button:has-text("Save Settings")');
+
+    // デフォルトではチェックされていない
+    await expect(checkbox).not.toBeChecked();
+
+    // チェックボックスをオンにして保存
+    await checkbox.check();
+    await saveButton.click();
+    await expect(page.locator("text=Settings saved successfully!")).toBeVisible();
+
+    // ページをリロード
+    await page.reload();
+
+    // チェック状態が保持されていることを確認
+    await expect(checkbox).toBeChecked();
+
+    // チェックボックスをオフにして保存
+    await checkbox.uncheck();
+    await saveButton.click();
+    await expect(page.locator("text=Settings saved successfully!")).toBeVisible();
+
+    // ページをリロード
+    await page.reload();
+
+    // チェック状態が保持されていることを確認
+    await expect(checkbox).not.toBeChecked();
+  });
+
+  test("should open new tabs in background when enabled", async ({ context, serviceWorker }) => {
+    // バックグラウンド設定を有効にする
+    await setExtensionSettings(context, {
+      newTab: {
+        position: "default",
+        background: true,
+      },
+    });
+
+    // 既存のタブを開く（data: URLを使用してネットワークアクセスを回避）
+    const initialTab = await context.newPage();
+    await initialTab.goto("data:text/html,<h1>Test Page 1</h1>");
+    await initialTab.bringToFront();
+
+    const beforeState = await getTabState(serviceWorker);
+    const currentActiveIndex = beforeState.activeTabIndex;
+
+    // 新しいタブを作成（Ctrl+T相当）
+    await createTabViaServiceWorker(serviceWorker);
+
+    // 少し待機
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // タブ状態を確認
+    const afterState = await getTabState(serviceWorker);
+
+    // 新しいタブが作成されたことを確認
+    expect(afterState.totalTabs).toBe(beforeState.totalTabs + 1);
+
+    // 元のタブがまだアクティブであることを確認（バックグラウンドで開いた）
+    expect(afterState.activeTabIndex).toBe(currentActiveIndex);
+  });
+
+  test("should open new tabs as active when disabled", async ({ context, serviceWorker }) => {
+    // バックグラウンド設定を無効にする（デフォルト）
+    await setExtensionSettings(context, {
+      newTab: {
+        position: "default",
+        background: false,
+      },
+    });
+
+    // 既存のタブを開く（data: URLを使用してネットワークアクセスを回避）
+    const initialTab = await context.newPage();
+    await initialTab.goto("data:text/html,<h1>Test Page 1</h1>");
+    await initialTab.bringToFront();
+
+    const beforeState = await getTabState(serviceWorker);
+
+    // 新しいタブを作成（Ctrl+T相当）
+    await createTabViaServiceWorker(serviceWorker);
+
+    // 少し待機して、タブの切り替えが完了するのを待つ
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // タブ状態を確認
+    const afterState = await getTabState(serviceWorker);
+
+    // 新しいタブが作成されたことを確認
+    expect(afterState.totalTabs).toBe(beforeState.totalTabs + 1);
+
+    // 新しいタブがアクティブになっていることを確認
+    expect(afterState.activeTabIndex).not.toBe(beforeState.activeTabIndex);
+  });
+
+  test("should work with different tab positions", async ({ context, serviceWorker }) => {
+    // バックグラウンド設定を有効にし、位置を「最初」に設定
+    await setExtensionSettings(context, {
+      newTab: {
+        position: "first",
+        background: true,
+      },
+    });
+
+    // 既存のタブを複数開く（data: URLを使用してネットワークアクセスを回避）
+    const tab1 = await context.newPage();
+    await tab1.goto("data:text/html,<h1>Test Page A</h1>");
+    const tab2 = await context.newPage();
+    await tab2.goto("data:text/html,<h1>Test Page B</h1>");
+    await tab2.bringToFront();
+
+    const beforeState = await getTabState(serviceWorker);
+
+    // 新しいタブを作成
+    await createTabViaServiceWorker(serviceWorker);
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // タブ状態を確認
+    const afterState = await getTabState(serviceWorker);
+
+    // 新しいタブが作成されたことを確認
+    expect(afterState.totalTabs).toBe(beforeState.totalTabs + 1);
+
+    // 新しいタブが最初の位置（0）に移動することを確認
+    // Service Workerの内部的なタイミングにより、
+    // 作成時のインデックスと最終的な位置が異なる可能性があるため、
+    // 最終的な状態を確認
+    await expect(async () => {
+      const tabs = await serviceWorker.evaluate(async () => {
+        const tabs = await chrome.tabs.query({ currentWindow: true });
+        return tabs.map(t => ({ index: t.index, url: t.url, active: t.active }));
+      });
+
+      // 新しいタブ（chrome://newtab/）が最初の位置にあることを確認
+      const newTab = tabs.find(t => t.url?.includes("newtab"));
+      if (newTab) {
+        expect(newTab.index).toBe(0);
+      }
+
+      // Test Page Bタブがまだアクティブであることを確認
+      const activeTab = tabs.find(t => t.active);
+      if (activeTab?.url) {
+        expect(activeTab.url).toContain("Test Page B");
+      }
+    }).toPass({
+      intervals: [100, 100, 100],
+      timeout: 3000,
+    });
+  });
+});

--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -28,7 +28,7 @@ test.describe("Settings Storage", () => {
     });
 
     expect(savedSettings).toEqual({
-      newTab: { position: "first" },
+      newTab: { position: "first", background: false },
       afterTabClosing: { activateTab: "inActivatedOrder" },
     });
   });

--- a/e2e/specs/tab-behavior.spec.ts
+++ b/e2e/specs/tab-behavior.spec.ts
@@ -3,7 +3,7 @@ import { createTabViaServiceWorker, getTabState, setExtensionSettings } from "@/
 
 test.describe("Tab Behavior - New Tab Position", () => {
   test("new tab opens at first position", async ({ context, serviceWorker }) => {
-    await setExtensionSettings(context, { newTab: { position: "first" } });
+    await setExtensionSettings(context, { newTab: { position: "first", background: false } });
 
     // 3つのタブを作成
     await context.newPage();
@@ -28,7 +28,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
   });
 
   test("new tab opens at last position", async ({ context, serviceWorker }) => {
-    await setExtensionSettings(context, { newTab: { position: "last" } });
+    await setExtensionSettings(context, { newTab: { position: "last", background: false } });
 
     // 3つのタブを作成
     await context.newPage();
@@ -53,7 +53,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
   });
 
   test("new tab opens to the right of current tab", async ({ context, serviceWorker }) => {
-    await setExtensionSettings(context, { newTab: { position: "right" } });
+    await setExtensionSettings(context, { newTab: { position: "right", background: false } });
 
     // 3つのタブを作成
     await context.newPage();
@@ -78,7 +78,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
   });
 
   test("new tab opens to the left of current tab", async ({ context, serviceWorker }) => {
-    await setExtensionSettings(context, { newTab: { position: "left" } });
+    await setExtensionSettings(context, { newTab: { position: "left", background: false } });
 
     // 3つのタブを作成
     await context.newPage();
@@ -103,7 +103,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
   });
 
   test("new tab opens at browser default position", async ({ context, serviceWorker }) => {
-    await setExtensionSettings(context, { newTab: { position: "default" } });
+    await setExtensionSettings(context, { newTab: { position: "default", background: false } });
 
     // 3つのタブを作成
     await context.newPage();
@@ -130,7 +130,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
 
   // エッジケースのテスト
   test("new tab opens to the left of first tab", async ({ context, serviceWorker }) => {
-    await setExtensionSettings(context, { newTab: { position: "left" } });
+    await setExtensionSettings(context, { newTab: { position: "left", background: false } });
 
     // 2つのタブを作成
     const tab1 = await context.newPage();
@@ -154,7 +154,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
   });
 
   test("new tab opens to the right of last tab", async ({ context, serviceWorker }) => {
-    await setExtensionSettings(context, { newTab: { position: "right" } });
+    await setExtensionSettings(context, { newTab: { position: "right", background: false } });
 
     // 3つのタブを作成
     await context.newPage();

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -7,6 +7,7 @@ import { APP_VERSION } from "@/src/version";
 export default function App() {
   const [activeTab, setActiveTab] = useState<"behavior" | "closing">("behavior");
   const [newTabPosition, setNewTabPosition] = useState<TabPosition>("default");
+  const [newTabBackground, setNewTabBackground] = useState(false);
   const [afterTabClosing, setAfterTabClosing] = useState<TabActivation>("default");
   const [isSaving, setIsSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState("");
@@ -18,6 +19,9 @@ export default function App() {
         if (result.settings.newTab?.position) {
           setNewTabPosition(result.settings.newTab.position);
         }
+        if (result.settings.newTab?.background !== undefined) {
+          setNewTabBackground(result.settings.newTab.background);
+        }
         if (result.settings.afterTabClosing?.activateTab) {
           setAfterTabClosing(result.settings.afterTabClosing.activateTab);
         }
@@ -27,6 +31,10 @@ export default function App() {
 
   const handleNewTabPositionChange = (value: string) => {
     setNewTabPosition(value as TabPosition);
+  };
+
+  const handleNewTabBackgroundChange = (checked: boolean) => {
+    setNewTabBackground(checked);
   };
 
   const handleAfterTabClosingChange = (value: string) => {
@@ -49,6 +57,7 @@ export default function App() {
           ...currentSettings,
           newTab: {
             position: newTabPosition,
+            background: newTabBackground,
           },
           afterTabClosing: {
             activateTab: afterTabClosing,
@@ -107,6 +116,8 @@ export default function App() {
               <TabBehavior
                 newTabPosition={newTabPosition}
                 onNewTabPositionChange={handleNewTabPositionChange}
+                newTabBackground={newTabBackground}
+                onNewTabBackgroundChange={handleNewTabBackgroundChange}
               />
             )}
 

--- a/entrypoints/options/TabBehavior.tsx
+++ b/entrypoints/options/TabBehavior.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import { Checkbox } from "@/entrypoints/options/ui/Checkbox";
 import { RadioGroup, type RadioOption } from "@/entrypoints/options/ui/RadioGroup";
 import { TabContent } from "@/entrypoints/options/ui/TabContent";
 import { TabSection } from "@/entrypoints/options/ui/TabSection";
@@ -7,6 +8,8 @@ import type { TabPosition } from "@/src/types";
 type Props = {
   newTabPosition: TabPosition;
   onNewTabPositionChange: (value: string) => void;
+  newTabBackground: boolean;
+  onNewTabBackgroundChange: (checked: boolean) => void;
 };
 
 const newTabOptions: RadioOption<TabPosition>[] = [
@@ -17,7 +20,12 @@ const newTabOptions: RadioOption<TabPosition>[] = [
   { value: "default", label: "Default (Browser default)" },
 ];
 
-export const TabBehavior: FC<Props> = ({ newTabPosition, onNewTabPositionChange }) => {
+export const TabBehavior: FC<Props> = ({
+  newTabPosition,
+  onNewTabPositionChange,
+  newTabBackground,
+  onNewTabBackgroundChange,
+}) => {
   return (
     <TabContent>
       <TabSection
@@ -30,6 +38,14 @@ export const TabBehavior: FC<Props> = ({ newTabPosition, onNewTabPositionChange 
           value={newTabPosition}
           onChange={onNewTabPositionChange}
         />
+        <div className="grid grid-cols-2 gap-4 mt-4">
+          <Checkbox
+            label="New Tab Background"
+            checked={newTabBackground}
+            onChange={onNewTabBackgroundChange}
+            name="newTabBackground"
+          />
+        </div>
       </TabSection>
 
       <TabSection

--- a/entrypoints/options/ui/Checkbox.tsx
+++ b/entrypoints/options/ui/Checkbox.tsx
@@ -1,0 +1,23 @@
+import type { FC } from "react";
+
+type Props = {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  name?: string;
+};
+
+export const Checkbox: FC<Props> = ({ label, checked, onChange, name }) => {
+  return (
+    <label className="flex items-center space-x-3 p-4 rounded-lg border border-gray-200 hover:border-chrome-blue hover:bg-blue-50 cursor-pointer transition-all">
+      <input
+        type="checkbox"
+        name={name}
+        checked={checked}
+        onChange={e => onChange(e.target.checked)}
+        className="w-4 h-4 text-chrome-blue bg-gray-100 border-gray-300 rounded focus:ring-chrome-blue focus:ring-2"
+      />
+      <span>{label}</span>
+    </label>
+  );
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export type TabOnActivateBehavior = "default" | "last" | "first";
 export type Settings = {
   newTab: {
     position: TabPosition;
+    background: boolean;
   };
   loadingPage: {
     position: TabPosition;
@@ -31,6 +32,7 @@ export type Settings = {
 export const defaultSettings: Settings = {
   newTab: {
     position: "default",
+    background: false,
   },
   loadingPage: {
     position: "default",


### PR DESCRIPTION
## 関連URL

- https://github.com/proshunsuke/tab-position-options-fork/issues/16

## 概要

- 新しいタブをバックグラウンドで開くためのチェックボックスオプションを追加
- 有効時は新しいタブを開いても現在のタブにフォーカスが維持される
- `lastActiveTabId`を優先的に使用してより確実に前のタブを特定する実装に改善
- 汎用的な`Checkbox`コンポーネントを作成し、既存のUIパターンに従った実装

## 実装内容

### 機能追加
- Settings型に`newTab.background: boolean`プロパティを追加（デフォルト: false）
- 汎用的な`Checkbox`UIコンポーネントを作成
- オプション画面のNew Tabセクションにチェックボックスを配置
- バックグラウンドタブ機能のロジックを実装

### 改善点
- `lastActiveTabId`を最優先で使用することで、前のアクティブタブをより確実に特定
- フォールバック順序: lastActiveTabId → openerTabId → 位置から推測
- E2Eテストで外部サイトへのアクセスを`data:` URLに置き換えて信頼性向上

## 既知の制限事項

⚠️ **ちらつきについて**
- 現在の実装では、新しいタブが一瞬アクティブになってから元のタブに戻るため、視覚的なちらつきが発生します
- これはChrome拡張機能APIの制限によるもので、ユーザーのCtrl+T操作を事前にインターセプトできないため完全な解決は困難です
- 将来的にキーボードショートカットによる代替実装を検討予定

## テスト

- 包括的なE2Eテストを追加（5つのテストケース）
- 既存のテストも`background`プロパティに対応するよう更新
- すべてのテストが成功することを確認済み

## チェック項目

- [x] Revert可能