### PR TITLE
feat: implement StateManager for Service Worker restart resilience

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,13 +1,18 @@
-import { loadSettings, setupStorageListener } from "@/src/storage";
+import { initializeSettingsState, setupStorageListener } from "@/src/storage";
 import { setupTabHandlers } from "@/src/tabs/handler";
+import { initializeAllStates } from "@/src/tabs/tabState";
 
 export default defineBackground(() => {
   // 初期設定を読み込む
   const initializeExtension = async () => {
     try {
-      await loadSettings();
+      // すべてのStateManagerを初期化（ストレージから復元）
+      await Promise.all([
+        initializeAllStates(), // タブ関連の状態（sessionStorage）
+        initializeSettingsState(), // 設定（localStorage）
+      ]);
     } catch (error) {
-      console.error("Failed to load settings:", error);
+      console.error("Failed to initialize extension:", error);
     }
   };
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,22 +1,48 @@
 import type { Settings } from "@/src/types";
 import { defaultSettings } from "@/src/types";
+import { StateManager } from "@/src/utils/stateManager";
 
-let cachedSettings: Settings | undefined;
+/**
+ * 設定の状態管理
+ * chrome.storage.localを使用（永続的な設定保存）
+ */
+const settingsState = new StateManager<Settings>("settings", defaultSettings, {
+  storageSource: "local",
+  serialize: value => value,
+  deserialize: value => (value as Settings) || defaultSettings,
+});
 
-export const loadSettings = async () => {
-  const result = await chrome.storage.local.get(["settings"]);
-  cachedSettings = (result.settings as Settings) || defaultSettings;
-  return cachedSettings;
-};
-
+/**
+ * ストレージの変更を監視
+ */
 export const setupStorageListener = () => {
-  chrome.storage.onChanged.addListener((changes, areaName) => {
+  chrome.storage.onChanged.addListener(async (changes, areaName) => {
     if (areaName === "local" && changes.settings) {
-      cachedSettings = changes.settings.newValue as Settings;
+      // ストレージが変更されたら、StateManagerの値も更新
+      const newSettings = changes.settings.newValue as Settings;
+      await settingsState.set(newSettings);
     }
   });
 };
 
-export const getCachedSettings = () => {
-  return cachedSettings || defaultSettings;
+/**
+ * 設定を取得（非同期）
+ * メモリキャッシュ → chrome.storage.local → デフォルト値の順でフォールバック
+ */
+export const getSettings = async () => {
+  return await settingsState.get();
+};
+
+/**
+ * 設定を保存
+ */
+export const saveSettings = async (settings: Settings) => {
+  await settingsState.set(settings);
+};
+
+/**
+ * すべての設定StateManagerを初期化
+ */
+export const initializeSettingsState = async () => {
+  await settingsState.initialize();
 };

--- a/src/tabs/tabState.ts
+++ b/src/tabs/tabState.ts
@@ -1,0 +1,111 @@
+import { StateManager } from "@/src/utils/stateManager";
+
+/**
+ * タブのアクティベーション情報
+ */
+type TabActivationInfo = {
+  tabId: number;
+  timestamp: number;
+};
+
+/**
+ * 最後にアクティブだったタブIDの状態管理
+ */
+export const lastActiveTabState = new StateManager<number | null>("lastActiveTabId", null);
+
+/**
+ * タブインデックスキャッシュの状態管理
+ * MapをArrayにシリアライズして保存
+ */
+export const tabIndexCacheState = new StateManager<[number, number][]>("tabIndexCache", [], {
+  serialize: value => value,
+  deserialize: value => (value as [number, number][]) || [],
+});
+
+/**
+ * タブアクティベーション履歴の状態管理
+ */
+export const tabActivationHistoryState = new StateManager<TabActivationInfo[]>(
+  "tabActivationHistory",
+  [],
+  {
+    serialize: value => value,
+    deserialize: value => (value as TabActivationInfo[]) || [],
+  },
+);
+
+/**
+ * タブソースマップの状態管理
+ * MapをArrayにシリアライズして保存
+ */
+export const tabSourceMapState = new StateManager<[number, number][]>("tabSourceMap", [], {
+  serialize: value => value,
+  deserialize: value => (value as [number, number][]) || [],
+});
+
+/**
+ * タブインデックスキャッシュをMapとして取得
+ */
+export const getTabIndexCache = async (): Promise<Map<number, number>> => {
+  const entries = await tabIndexCacheState.get();
+  return new Map(entries);
+};
+
+/**
+ * タブインデックスキャッシュをMapから設定
+ */
+export const setTabIndexCache = async (cache: Map<number, number>): Promise<void> => {
+  await tabIndexCacheState.set(Array.from(cache.entries()));
+};
+
+/**
+ * タブインデックスキャッシュを更新
+ */
+export const updateTabIndexCache = async (tabId: number): Promise<void> => {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    if (tab) {
+      const cache = await getTabIndexCache();
+      cache.set(tabId, tab.index);
+      await setTabIndexCache(cache);
+    }
+  } catch (_error) {
+    // タブが既に存在しない場合は無視
+  }
+};
+
+/**
+ * タブインデックスキャッシュから削除
+ */
+export const deleteFromTabIndexCache = async (tabId: number): Promise<void> => {
+  const cache = await getTabIndexCache();
+  cache.delete(tabId);
+  await setTabIndexCache(cache);
+};
+
+/**
+ * タブソースマップをMapとして取得
+ */
+export const getTabSourceMap = async (): Promise<Map<number, number>> => {
+  const entries = await tabSourceMapState.get();
+  return new Map(entries);
+};
+
+/**
+ * タブソースマップをMapから設定
+ */
+export const setTabSourceMap = async (sourceMap: Map<number, number>): Promise<void> => {
+  await tabSourceMapState.set(Array.from(sourceMap.entries()));
+};
+
+/**
+ * すべてのStateManagerを初期化
+ */
+export const initializeAllStates = async (): Promise<void> => {
+  await Promise.all([
+    lastActiveTabState.initialize(),
+    tabIndexCacheState.initialize(),
+    tabActivationHistoryState.initialize(),
+    tabSourceMapState.initialize(),
+  ]);
+};

--- a/src/utils/stateManager.ts
+++ b/src/utils/stateManager.ts
@@ -1,0 +1,154 @@
+/**
+ * Service Worker終了後も状態を維持するための汎用的な状態管理クラス
+ *
+ * 3層構造のフォールバック機構:
+ * 1. メモリキャッシュ（最速）
+ * 2. ストレージソース（session/local/カスタム）
+ * 3. デフォルト値（必ずフォールバック）
+ */
+
+type StorageSource = "session" | "local" | "custom";
+
+type StateManagerOptions<T> = {
+  serialize?: (value: T) => unknown;
+  deserialize?: (value: unknown) => T;
+  storageSource?: StorageSource;
+  // カスタムストレージソース用
+  getFromSource?: () => Promise<T | undefined>;
+  saveToSource?: (value: T) => Promise<void>;
+};
+
+export class StateManager<T> {
+  private memoryCache: T | undefined;
+  private readonly key: string;
+  private readonly defaultValue: T;
+  private readonly serialize: (value: T) => unknown;
+  private readonly deserialize: (value: unknown) => T;
+
+  private readonly storageSource: StorageSource;
+  private readonly getFromSource?: () => Promise<T | undefined>;
+  private readonly saveToSource?: (value: T) => Promise<void>;
+
+  constructor(key: string, defaultValue: T, options?: StateManagerOptions<T>) {
+    this.key = key;
+    this.defaultValue = defaultValue;
+    this.serialize = options?.serialize || (v => v);
+    this.deserialize = options?.deserialize || (v => v as T);
+    this.storageSource = options?.storageSource || "session";
+    this.getFromSource = options?.getFromSource;
+    this.saveToSource = options?.saveToSource;
+  }
+
+  /**
+   * 値を取得する
+   * メモリ → session → デフォルト値の順でフォールバック
+   */
+  async get(): Promise<T> {
+    // 1. メモリキャッシュから取得（最速）
+    if (this.memoryCache !== undefined) {
+      return this.memoryCache;
+    }
+
+    // 2. ストレージソースから取得
+    try {
+      let value: T | undefined;
+
+      if (this.storageSource === "custom" && this.getFromSource) {
+        // カスタムソースから取得
+        value = await this.getFromSource();
+      } else if (typeof chrome !== "undefined" && chrome.storage) {
+        // Chrome storageから取得
+        const storage =
+          this.storageSource === "local" ? chrome.storage.local : chrome.storage.session;
+        if (storage) {
+          const result = await storage.get(this.key);
+          if (result[this.key] !== undefined) {
+            value = this.deserialize(result[this.key]);
+          }
+        }
+      }
+
+      if (value !== undefined) {
+        this.memoryCache = value;
+        return this.memoryCache;
+      }
+    } catch (error) {
+      // ストレージが使えない場合は継続
+      console.warn(`Failed to read from ${this.storageSource} storage: ${this.key}`, error);
+    }
+
+    // 3. デフォルト値を返す（必ずフォールバック）
+    return this.defaultValue;
+  }
+
+  /**
+   * 値を設定する
+   * メモリとsessionの両方に保存
+   */
+  async set(value: T): Promise<void> {
+    // メモリに即座に反映
+    this.memoryCache = value;
+
+    // バックグラウンドでストレージに保存（非同期だがエラーは無視）
+    try {
+      if (this.storageSource === "custom" && this.saveToSource) {
+        // カスタムソースに保存
+        await this.saveToSource(value);
+      } else if (typeof chrome !== "undefined" && chrome.storage) {
+        // Chrome storageに保存
+        const storage =
+          this.storageSource === "local" ? chrome.storage.local : chrome.storage.session;
+        if (storage) {
+          await storage.set({ [this.key]: this.serialize(value) });
+        }
+      }
+    } catch (error) {
+      console.warn(`Failed to save to ${this.storageSource} storage: ${this.key}`, error);
+    }
+  }
+
+  /**
+   * 値をクリアする
+   */
+  async clear(): Promise<void> {
+    this.memoryCache = undefined;
+
+    try {
+      if (this.storageSource === "custom") {
+        // カスタムソースはクリア対応なし（saveToSourceでundefinedを保存）
+        if (this.saveToSource) {
+          await this.saveToSource(this.defaultValue);
+        }
+      } else if (typeof chrome !== "undefined" && chrome.storage) {
+        const storage =
+          this.storageSource === "local" ? chrome.storage.local : chrome.storage.session;
+        if (storage) {
+          await storage.remove(this.key);
+        }
+      }
+    } catch (error) {
+      console.warn(`Failed to clear ${this.storageSource} storage: ${this.key}`, error);
+    }
+  }
+
+  /**
+   * Service Worker起動時にストレージから復元
+   */
+  async initialize(): Promise<void> {
+    try {
+      // getメソッドを再利用（メモリキャッシュをクリアしてから）
+      this.memoryCache = undefined;
+      await this.get();
+    } catch (error) {
+      // エラーは無視してデフォルト値を使用
+      console.warn(`Failed to initialize from ${this.storageSource} storage: ${this.key}`, error);
+    }
+  }
+
+  /**
+   * 現在のメモリキャッシュの値を取得（デバッグ用）
+   */
+  getCached(): T | undefined {
+    return this.memoryCache;
+  }
+}


### PR DESCRIPTION
## 関連URL

- https://github.com/proshunsuke/tab-position-options-fork/pull/8
- https://github.com/proshunsuke/tab-position-options-fork/issues/9

## 概要

- Service Worker再起動時の状態喪失問題を解決するStateManagerを実装
- グローバル変数から永続的な状態管理への移行を完了
- 3層のフォールバック機構（メモリ、ストレージ、デフォルト値）を実装
- タブクローズ時の動作を修正し、適切な状態永続化を実現
- すべてのE2Eテストが成功（31/31 passed）

## チェック項目

- [x] Revert可能
