### PR TITLE
chore: release 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.3
+- Fixed unexpected behavior when Service Worker restarts after 30 seconds of inactivity
+
 ## 0.0.2
 - Fixed "Left Tab" setting not working correctly when closing tabs opened via target="_blank" links
 - Fixed tab order preservation during browser session restore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tab-position-options-fork",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Chrome extension to control where new tabs are opened",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 関連URL

- https://github.com/proshunsuke/tab-position-options-fork/issues/9

## 概要

- Version 0.0.3のリリース
- Service Workerが30秒間の非アクティブ状態後に再起動した際の予期しない動作を修正

## チェック項目

- [x] Revert可能
