### PR TITLE
feat: add New Tab Background option

### DIFF
--- a/e2e/specs/browser-startup-tab-order.spec.ts
+++ b/e2e/specs/browser-startup-tab-order.spec.ts
@@ -12,7 +12,7 @@ test.describe("Browser Startup Tab Order", () => {
   }) => {
     // "Always first" 設定を適用
     await setExtensionSettings(context, {
-      newTab: { position: "first" },
+      newTab: { position: "first", openInBackground: false },
     });
 
     // Service Worker内でセッション復元をシミュレート
@@ -81,7 +81,7 @@ test.describe("Browser Startup Tab Order", () => {
   }) => {
     // "Always last" 設定を適用
     await setExtensionSettings(context, {
-      newTab: { position: "last" },
+      newTab: { position: "last", openInBackground: false },
     });
 
     // Service Worker内でセッション復元をシミュレート
@@ -164,7 +164,7 @@ test.describe("Browser Startup Tab Order", () => {
 
     // "Always first" 設定
     await setExtensionSettings(context, {
-      newTab: { position: "first" },
+      newTab: { position: "first", openInBackground: false },
     });
 
     // ブラウザ起動をシミュレート
@@ -229,7 +229,7 @@ test.describe("Browser Startup Tab Order", () => {
   }) => {
     // "Right of current tab" 設定
     await setExtensionSettings(context, {
-      newTab: { position: "right" },
+      newTab: { position: "right", openInBackground: false },
     });
 
     // セッション復元を開始

--- a/e2e/specs/external-tab-opening.spec.ts
+++ b/e2e/specs/external-tab-opening.spec.ts
@@ -34,7 +34,7 @@ test.describe("External Tab Opening Behavior", () => {
     await tab2.bringToFront();
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    await setExtensionSettings(context, { newTab: { position: "right" } });
+    await setExtensionSettings(context, { newTab: { position: "right", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     expect(beforeState.totalTabs).toBe(initialTabCount + 3);
@@ -77,7 +77,7 @@ test.describe("External Tab Opening Behavior", () => {
     await tab2.bringToFront();
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    await setExtensionSettings(context, { newTab: { position: "left" } });
+    await setExtensionSettings(context, { newTab: { position: "left", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     expect(beforeState.totalTabs).toBe(initialTabCount + 3);
@@ -117,7 +117,7 @@ test.describe("External Tab Opening Behavior", () => {
     await tab2.bringToFront();
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    await setExtensionSettings(context, { newTab: { position: "first" } });
+    await setExtensionSettings(context, { newTab: { position: "first", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     expect(beforeState.totalTabs).toBe(initialTabCount + 3);
@@ -157,7 +157,7 @@ test.describe("External Tab Opening Behavior", () => {
     await tab2.bringToFront();
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    await setExtensionSettings(context, { newTab: { position: "last" } });
+    await setExtensionSettings(context, { newTab: { position: "last", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     expect(beforeState.totalTabs).toBe(initialTabCount + 3);
@@ -203,7 +203,7 @@ test.describe("External Tab Opening Behavior", () => {
     await tab3.bringToFront();
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    await setExtensionSettings(context, { newTab: { position: "right" } });
+    await setExtensionSettings(context, { newTab: { position: "right", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     expect(beforeState.totalTabs).toBe(initialTabCount + 5);
@@ -246,7 +246,9 @@ test.describe("External Tab Opening Behavior", () => {
     await tab2.bringToFront();
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    await setExtensionSettings(context, { newTab: { position: "default" } });
+    await setExtensionSettings(context, {
+      newTab: { position: "default", openInBackground: false },
+    });
 
     const beforeState = await getTabState(serviceWorker);
     expect(beforeState.totalTabs).toBe(initialTabCount + 3);
@@ -298,7 +300,7 @@ test.describe("External Tab Opening with Race Condition", () => {
     await tab2.bringToFront();
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    await setExtensionSettings(context, { newTab: { position: "right" } });
+    await setExtensionSettings(context, { newTab: { position: "right", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     expect(beforeState.totalTabs).toBe(initialTabCount + 3);
@@ -342,7 +344,7 @@ test.describe("External Tab Opening with Race Condition", () => {
     await tab2.bringToFront();
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    await setExtensionSettings(context, { newTab: { position: "left" } });
+    await setExtensionSettings(context, { newTab: { position: "left", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     expect(beforeState.totalTabs).toBe(initialTabCount + 3);
@@ -386,7 +388,7 @@ test.describe("External Tab Opening with Race Condition", () => {
     await tab2.bringToFront();
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    await setExtensionSettings(context, { newTab: { position: "first" } });
+    await setExtensionSettings(context, { newTab: { position: "first", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     expect(beforeState.totalTabs).toBe(initialTabCount + 3);
@@ -429,7 +431,7 @@ test.describe("External Tab Opening with Race Condition", () => {
     await tab2.bringToFront();
     await new Promise(resolve => setTimeout(resolve, 200));
 
-    await setExtensionSettings(context, { newTab: { position: "last" } });
+    await setExtensionSettings(context, { newTab: { position: "last", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     expect(beforeState.totalTabs).toBe(initialTabCount + 3);

--- a/e2e/specs/options.spec.ts
+++ b/e2e/specs/options.spec.ts
@@ -77,6 +77,9 @@ test.describe("Options Page", () => {
     // Tab Behaviorタブの内容を確認
     await optionsPage.click('button:has-text("Tab Behavior")');
     await expect(optionsPage.locator('h2:has-text("New Tab")')).toBeVisible();
+    // New Tab Backgroundチェックボックスの存在を確認
+    await expect(optionsPage.locator('label:has-text("New Tab Background")')).toBeVisible();
+    await expect(optionsPage.locator('input[name="openInBackground"]')).toBeVisible();
 
     // Tab Closingタブの内容を確認
     await optionsPage.click('button:has-text("Tab Closing")');

--- a/e2e/specs/tab-behavior-background.spec.ts
+++ b/e2e/specs/tab-behavior-background.spec.ts
@@ -1,0 +1,260 @@
+import { expect, test } from "@/e2e/fixtures";
+import {
+  clearExtensionStorage,
+  createTabViaServiceWorker,
+  getTabState,
+  setExtensionSettings,
+} from "@/e2e/utils/helpers";
+
+test.describe("Tab Behavior - New Tab Background", () => {
+  test.beforeEach(async ({ serviceWorker }) => {
+    await clearExtensionStorage(serviceWorker);
+  });
+
+  test("should open new tab at first position in background", async ({
+    context,
+    serviceWorker,
+  }) => {
+    // 3つのタブを作成
+    await context.newPage();
+    const tab2 = await context.newPage();
+    await context.newPage();
+
+    // tab2をアクティブに
+    await tab2.bringToFront();
+
+    await setExtensionSettings(context, {
+      newTab: { position: "first", openInBackground: true },
+    });
+
+    const beforeState = await getTabState(serviceWorker);
+    const originalActiveIndex = beforeState.activeTabIndex;
+
+    await createTabViaServiceWorker(serviceWorker);
+
+    // 新しいタブは最初（インデックス0）に作成され、元のタブがアクティブのままであるべき
+    await expect(async () => {
+      const state = await getTabState(serviceWorker);
+      expect(state.totalTabs).toBe(beforeState.totalTabs + 1);
+      // 元のタブがアクティブのまま（インデックスは新しいタブの挿入により+1される）
+      expect(state.activeTabIndex).toBe(originalActiveIndex + 1);
+    }).toPass({
+      intervals: [100, 100, 100],
+      timeout: 3000,
+    });
+  });
+
+  test("should open new tab at last position in background", async ({ context, serviceWorker }) => {
+    // 3つのタブを作成
+    await context.newPage();
+    const tab2 = await context.newPage();
+    await context.newPage();
+
+    // tab2をアクティブに
+    await tab2.bringToFront();
+
+    await setExtensionSettings(context, {
+      newTab: { position: "last", openInBackground: true },
+    });
+
+    const beforeState = await getTabState(serviceWorker);
+    const originalActiveIndex = beforeState.activeTabIndex;
+
+    await createTabViaServiceWorker(serviceWorker);
+
+    // 新しいタブは最後に作成され、元のタブがアクティブのままであるべき
+    await expect(async () => {
+      const state = await getTabState(serviceWorker);
+      expect(state.totalTabs).toBe(beforeState.totalTabs + 1);
+      // 元のタブがアクティブのまま（位置は変わらない）
+      expect(state.activeTabIndex).toBe(originalActiveIndex);
+    }).toPass({
+      intervals: [100, 100, 100],
+      timeout: 3000,
+    });
+  });
+
+  test("should open new tab to the right in background", async ({ context, serviceWorker }) => {
+    // 3つのタブを作成
+    await context.newPage();
+    const tab2 = await context.newPage();
+    await context.newPage();
+
+    // tab2（インデックス1）をアクティブに
+    await tab2.bringToFront();
+
+    await setExtensionSettings(context, {
+      newTab: { position: "right", openInBackground: true },
+    });
+
+    const beforeState = await getTabState(serviceWorker);
+    const originalActiveIndex = beforeState.activeTabIndex;
+
+    await createTabViaServiceWorker(serviceWorker);
+
+    // 新しいタブは現在のタブの右側に作成され、元のタブがアクティブのままであるべき
+    await expect(async () => {
+      const state = await getTabState(serviceWorker);
+      expect(state.totalTabs).toBe(beforeState.totalTabs + 1);
+      // 元のタブがアクティブのまま（位置は変わらない）
+      expect(state.activeTabIndex).toBe(originalActiveIndex);
+    }).toPass({
+      intervals: [100, 100, 100],
+      timeout: 3000,
+    });
+  });
+
+  test("should open new tab to the left in background", async ({ context, serviceWorker }) => {
+    // 3つのタブを作成
+    await context.newPage();
+    const tab2 = await context.newPage();
+    await context.newPage();
+
+    // tab2（インデックス1）をアクティブに
+    await tab2.bringToFront();
+
+    await setExtensionSettings(context, {
+      newTab: { position: "left", openInBackground: true },
+    });
+
+    const beforeState = await getTabState(serviceWorker);
+    const originalActiveIndex = beforeState.activeTabIndex;
+
+    await createTabViaServiceWorker(serviceWorker);
+
+    // 新しいタブは現在のタブの左側に作成され、元のタブがアクティブのままであるべき
+    await expect(async () => {
+      const state = await getTabState(serviceWorker);
+      expect(state.totalTabs).toBe(beforeState.totalTabs + 1);
+      // 元のタブがアクティブのまま（新しいタブが左に挿入されたため+1）
+      expect(state.activeTabIndex).toBe(originalActiveIndex + 1);
+    }).toPass({
+      intervals: [100, 100, 100],
+      timeout: 3000,
+    });
+  });
+
+  test("should open new tab at default position in background", async ({
+    context,
+    serviceWorker,
+  }) => {
+    // 3つのタブを作成
+    await context.newPage();
+    const tab2 = await context.newPage();
+    await context.newPage();
+
+    // tab2をアクティブに
+    await tab2.bringToFront();
+
+    await setExtensionSettings(context, {
+      newTab: { position: "default", openInBackground: true },
+    });
+
+    const beforeState = await getTabState(serviceWorker);
+    const originalActiveIndex = beforeState.activeTabIndex;
+
+    await createTabViaServiceWorker(serviceWorker);
+
+    // デフォルトでは、新しいタブは最後に作成され、元のタブがアクティブのままであるべき
+    await expect(async () => {
+      const state = await getTabState(serviceWorker);
+      expect(state.totalTabs).toBe(beforeState.totalTabs + 1);
+      // 元のタブがアクティブのまま（位置は変わらない）
+      expect(state.activeTabIndex).toBe(originalActiveIndex);
+    }).toPass({
+      intervals: [100, 100, 100],
+      timeout: 3000,
+    });
+  });
+
+  test("should maintain active tab when opening multiple tabs in background", async ({
+    context,
+    serviceWorker,
+  }) => {
+    // 2つのタブを作成
+    await context.newPage();
+    const tab2 = await context.newPage();
+
+    // tab2をアクティブに
+    await tab2.bringToFront();
+
+    await setExtensionSettings(context, {
+      newTab: { position: "right", openInBackground: true },
+    });
+
+    const beforeState = await getTabState(serviceWorker);
+    const originalActiveIndex = beforeState.activeTabIndex;
+
+    // 3つのタブを連続でバックグラウンドで作成
+    await createTabViaServiceWorker(serviceWorker);
+    await createTabViaServiceWorker(serviceWorker);
+    await createTabViaServiceWorker(serviceWorker);
+
+    // すべてのタブがバックグラウンドで作成され、元のタブがアクティブのままであるべき
+    await expect(async () => {
+      const state = await getTabState(serviceWorker);
+      expect(state.totalTabs).toBe(beforeState.totalTabs + 3);
+      // 元のタブがアクティブのまま（位置は変わらない、右側に追加されるため）
+      expect(state.activeTabIndex).toBe(originalActiveIndex);
+    }).toPass({
+      intervals: [100, 100, 100],
+      timeout: 3000,
+    });
+  });
+
+  test("should keep original tab active with edge positions in background", async ({
+    context,
+    serviceWorker,
+  }) => {
+    // エッジケース：最初のタブでleftポジション、最後のタブでrightポジション
+
+    // Step 1: 最初のタブでleftポジションをテスト
+    const tab1 = await context.newPage();
+    await context.newPage();
+    await context.newPage();
+
+    // 最初のタブをアクティブに
+    await tab1.bringToFront();
+
+    await setExtensionSettings(context, {
+      newTab: { position: "left", openInBackground: true },
+    });
+
+    const beforeState1 = await getTabState(serviceWorker);
+    await createTabViaServiceWorker(serviceWorker);
+
+    // 最初のタブの左側は存在しないので、同じ位置に作成され、元のタブがアクティブのまま
+    await expect(async () => {
+      const state = await getTabState(serviceWorker);
+      expect(state.totalTabs).toBe(beforeState1.totalTabs + 1);
+      // 元のタブがアクティブのまま（左に新しいタブが挿入されたため+1）
+      expect(state.activeTabIndex).toBe(beforeState1.activeTabIndex + 1);
+    }).toPass({
+      intervals: [100, 100, 100],
+      timeout: 3000,
+    });
+
+    // Step 2: 最後のタブでrightポジションをテスト
+    const pages = context.pages();
+    const lastTab = pages[pages.length - 1];
+    await lastTab.bringToFront();
+
+    await setExtensionSettings(context, {
+      newTab: { position: "right", openInBackground: true },
+    });
+
+    const beforeState2 = await getTabState(serviceWorker);
+    await createTabViaServiceWorker(serviceWorker);
+
+    // 最後のタブの右側は新しい最後のタブになり、元のタブがアクティブのまま
+    await expect(async () => {
+      const state = await getTabState(serviceWorker);
+      expect(state.totalTabs).toBe(beforeState2.totalTabs + 1);
+      // 元のタブがアクティブのまま（右側に追加されるため位置は変わらない）
+      expect(state.activeTabIndex).toBe(beforeState2.activeTabIndex);
+    }).toPass({
+      intervals: [100, 100, 100],
+      timeout: 3000,
+    });
+  });
+});

--- a/e2e/specs/tab-behavior.spec.ts
+++ b/e2e/specs/tab-behavior.spec.ts
@@ -19,7 +19,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
     // tab3をアクティブに
     await tab3.bringToFront();
 
-    await setExtensionSettings(context, { newTab: { position: "first" } });
+    await setExtensionSettings(context, { newTab: { position: "first", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     await createTabViaServiceWorker(serviceWorker);
@@ -44,7 +44,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
     // tab2をアクティブに
     await tab2.bringToFront();
 
-    await setExtensionSettings(context, { newTab: { position: "last" } });
+    await setExtensionSettings(context, { newTab: { position: "last", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     await createTabViaServiceWorker(serviceWorker);
@@ -69,7 +69,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
     // tab2（インデックス1）をアクティブに
     await tab2.bringToFront();
 
-    await setExtensionSettings(context, { newTab: { position: "right" } });
+    await setExtensionSettings(context, { newTab: { position: "right", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     await createTabViaServiceWorker(serviceWorker);
@@ -94,7 +94,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
     // tab2（インデックス1）をアクティブに
     await tab2.bringToFront();
 
-    await setExtensionSettings(context, { newTab: { position: "left" } });
+    await setExtensionSettings(context, { newTab: { position: "left", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     await createTabViaServiceWorker(serviceWorker);
@@ -119,7 +119,9 @@ test.describe("Tab Behavior - New Tab Position", () => {
     // tab2をアクティブに
     await tab2.bringToFront();
 
-    await setExtensionSettings(context, { newTab: { position: "default" } });
+    await setExtensionSettings(context, {
+      newTab: { position: "default", openInBackground: false },
+    });
 
     const beforeState = await getTabState(serviceWorker);
     await createTabViaServiceWorker(serviceWorker);
@@ -145,7 +147,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
     // 最初のタブをアクティブに
     await tab1.bringToFront();
 
-    await setExtensionSettings(context, { newTab: { position: "left" } });
+    await setExtensionSettings(context, { newTab: { position: "left", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     await createTabViaServiceWorker(serviceWorker);
@@ -170,7 +172,7 @@ test.describe("Tab Behavior - New Tab Position", () => {
     // 最後のタブをアクティブに
     await tab3.bringToFront();
 
-    await setExtensionSettings(context, { newTab: { position: "right" } });
+    await setExtensionSettings(context, { newTab: { position: "right", openInBackground: false } });
 
     const beforeState = await getTabState(serviceWorker);
     await createTabViaServiceWorker(serviceWorker);

--- a/entrypoints/options/App.tsx
+++ b/entrypoints/options/App.tsx
@@ -11,6 +11,7 @@ import type { TabActivation, TabPosition } from "@/src/types";
 export default function App() {
   const [activeTab, setActiveTab] = useState<"behavior" | "closing">("behavior");
   const [newTabPosition, setNewTabPosition] = useState<TabPosition>("default");
+  const [openInBackground, setOpenInBackground] = useState(false);
   const [afterTabClosing, setAfterTabClosing] = useState<TabActivation>("default");
   const [isSaving, setIsSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState("");
@@ -23,6 +24,9 @@ export default function App() {
       if (settings.newTab?.position) {
         setNewTabPosition(settings.newTab.position);
       }
+      if (settings.newTab?.openInBackground !== undefined) {
+        setOpenInBackground(settings.newTab.openInBackground);
+      }
       if (settings.afterTabClosing?.activateTab) {
         setAfterTabClosing(settings.afterTabClosing.activateTab);
       }
@@ -31,6 +35,10 @@ export default function App() {
 
   const handleNewTabPositionChange = (value: string) => {
     setNewTabPosition(value as TabPosition);
+  };
+
+  const handleOpenInBackgroundChange = (checked: boolean) => {
+    setOpenInBackground(checked);
   };
 
   const handleAfterTabClosingChange = (value: string) => {
@@ -47,6 +55,7 @@ export default function App() {
         ...currentSettings,
         newTab: {
           position: newTabPosition,
+          openInBackground,
         },
         afterTabClosing: {
           activateTab: afterTabClosing,
@@ -104,6 +113,8 @@ export default function App() {
               <TabBehavior
                 newTabPosition={newTabPosition}
                 onNewTabPositionChange={handleNewTabPositionChange}
+                openInBackground={openInBackground}
+                onOpenInBackgroundChange={handleOpenInBackgroundChange}
               />
             )}
 

--- a/entrypoints/options/TabBehavior.tsx
+++ b/entrypoints/options/TabBehavior.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import { Checkbox } from "@/entrypoints/options/ui/Checkbox";
 import { RadioGroup, type RadioOption } from "@/entrypoints/options/ui/RadioGroup";
 import { TabContent } from "@/entrypoints/options/ui/TabContent";
 import { TabSection } from "@/entrypoints/options/ui/TabSection";
@@ -7,6 +8,8 @@ import type { TabPosition } from "@/src/types";
 type Props = {
   newTabPosition: TabPosition;
   onNewTabPositionChange: (value: string) => void;
+  openInBackground: boolean;
+  onOpenInBackgroundChange: (checked: boolean) => void;
 };
 
 const NewTabOptions: RadioOption<TabPosition>[] = [
@@ -17,7 +20,12 @@ const NewTabOptions: RadioOption<TabPosition>[] = [
   { value: "default", label: "Default (Browser default)" },
 ];
 
-export const TabBehavior: FC<Props> = ({ newTabPosition, onNewTabPositionChange }) => {
+export const TabBehavior: FC<Props> = ({
+  newTabPosition,
+  onNewTabPositionChange,
+  openInBackground,
+  onOpenInBackgroundChange,
+}) => {
   return (
     <TabContent>
       <TabSection
@@ -30,6 +38,15 @@ export const TabBehavior: FC<Props> = ({ newTabPosition, onNewTabPositionChange 
           value={newTabPosition}
           onChange={onNewTabPositionChange}
         />
+        <div className="mt-4 grid grid-cols-2 gap-4">
+          <Checkbox
+            name="openInBackground"
+            label="New Tab Background"
+            checked={openInBackground}
+            onChange={onOpenInBackgroundChange}
+          />
+          <div></div>
+        </div>
       </TabSection>
 
       <TabSection

--- a/entrypoints/options/ui/Checkbox.tsx
+++ b/entrypoints/options/ui/Checkbox.tsx
@@ -1,0 +1,27 @@
+import type { FC } from "react";
+
+type Props = {
+  name: string;
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  description?: string;
+};
+
+export const Checkbox: FC<Props> = ({ name, label, checked, onChange, description }) => {
+  return (
+    <label className="flex items-center space-x-3 p-4 rounded hover:bg-gray-50 cursor-pointer transition-colors">
+      <input
+        type="checkbox"
+        name={name}
+        checked={checked}
+        onChange={e => onChange(e.target.checked)}
+        className="w-4 h-4 text-chrome-blue rounded border-gray-300 focus:ring-chrome-blue"
+      />
+      <div className="flex-1">
+        <span className="text-gray-900">{label}</span>
+        {description && <span className="block text-sm text-gray-500 mt-1">{description}</span>}
+      </div>
+    </label>
+  );
+};

--- a/src/tabs/handleNewTab.ts
+++ b/src/tabs/handleNewTab.ts
@@ -6,6 +6,7 @@ import { getLastActiveTabIdByNewTabId } from "@/src/tabs/state/activationHistory
 import { setTabIndex } from "@/src/tabs/state/indexCache";
 import { recordTabSource } from "@/src/tabs/state/sourceMap";
 import { getTabSnapshot, updateTabSnapshot } from "@/src/tabs/state/tabSnapshot";
+import type { TabPosition } from "@/src/types";
 
 export const handleNewTab = async (tab: chrome.tabs.Tab) => {
   // Service Worker初期化チェック
@@ -13,49 +14,90 @@ export const handleNewTab = async (tab: chrome.tabs.Tab) => {
     await initializeAllStates();
   }
 
-  if (!tab.id) {
+  const tabId = tab.id;
+  const tabIndex = tab.index;
+  const tabOpenerTabId = tab.openerTabId;
+
+  if (!tabId) {
     return;
   }
 
-  // 新規タブの位置を計算
-  const newIndex = getNewIndex(tab.id, tab.index);
+  const settings = getSettings();
+  const lastActiveTabId = getLastActiveTabIdByNewTabId(tabId);
 
-  // それぞれのステートを更新
-  setTabIndex(tab.id, newIndex);
-  if (tab.openerTabId) {
-    recordTabSource(tab.id, tab.openerTabId);
-  }
-
-  // 新規タブの位置が変更される場合は移動
-  if (newIndex !== tab.index) {
-    chrome.tabs.move(tab.id, { index: newIndex }).finally(() => {
-      updateTabSnapshot();
+  // バックグラウンドで開く場合は先にフォーカスを戻す
+  if (settings.newTab.openInBackground && lastActiveTabId) {
+    chrome.tabs.update(lastActiveTabId, { active: true }).finally(() => {
+      positionTabAndUpdateStates(
+        settings.newTab.position,
+        tabId,
+        tabIndex,
+        lastActiveTabId,
+        tabOpenerTabId,
+      );
     });
   } else {
-    updateTabSnapshot();
+    positionTabAndUpdateStates(
+      settings.newTab.position,
+      tabId,
+      tabIndex,
+      lastActiveTabId,
+      tabOpenerTabId,
+    );
   }
 };
 
-const getNewIndex = (id: number, index: number) => {
+/**
+ * タブ位置を移動するのと、合わせて適切なタイミングでステートの更新を行う責務を担う
+ */
+const positionTabAndUpdateStates = (
+  position: TabPosition,
+  tabId: number,
+  tabIndex: number,
+  lastActiveTabId: number | null,
+  tabOpenerTabId?: number,
+) => {
+  const newIndex = getNewIndex(position, lastActiveTabId, tabIndex);
+  if (newIndex !== tabIndex) {
+    chrome.tabs.move(tabId, { index: newIndex }).finally(() => {
+      updateStates(tabId, newIndex, tabOpenerTabId);
+    });
+  } else {
+    updateStates(tabId, newIndex, tabOpenerTabId);
+  }
+};
+
+/**
+ * 設定を元に新規タブのあるべき位置を計算して返す
+ */
+const getNewIndex = (position: TabPosition, lastActiveTabId: number | null, index: number) => {
   // セッション復元によるタブかチェック
   const isSessionRestore = isSessionRestoreTab();
   if (isSessionRestore) {
     // タブの追跡は記録するが、位置調整はスキップ
     return index;
   }
-  const settings = getSettings();
 
-  // 現在はnewTabの設定をすべてのタブに適用（ブックマークからのタブも含む）
-  const position = settings.newTab.position;
   // デフォルト・lastの場合は何もしない
   if (["default", "last"].includes(position)) {
     return index;
   }
 
-  const lastActiveTabId = getLastActiveTabIdByNewTabId(id);
   if (lastActiveTabId === null) {
     return index;
   }
   const tabs = getTabSnapshot();
   return calculateNewTabIndex(position, tabs, lastActiveTabId) ?? index;
+};
+
+/**
+ * ステートの更新処理をまとめる
+ * ステート更新はハンドラーの最後に一度だけ行う
+ */
+const updateStates = (tabId: number, newIndex: number, tabOpenerTabId?: number) => {
+  setTabIndex(tabId, newIndex);
+  if (tabOpenerTabId) {
+    recordTabSource(tabId, tabOpenerTabId);
+  }
+  updateTabSnapshot();
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export type TabOnActivateBehavior = "default" | "last" | "first";
 export type Settings = {
   newTab: {
     position: TabPosition;
+    openInBackground: boolean;
   };
   loadingPage: {
     position: TabPosition;
@@ -31,6 +32,7 @@ export type Settings = {
 export const DEFAULT_SETTINGS: Settings = {
   newTab: {
     position: "default",
+    openInBackground: false,
   },
   loadingPage: {
     position: "default",


### PR DESCRIPTION
## Related URLs

- https://github.com/proshunsuke/tab-position-options-fork/issues/16

## Overview

Adds a "New Tab Background" option that allows users to open new tabs in the background while keeping the current tab active.

### Problem
When users open a new tab (Ctrl+T or + button), Chrome immediately switches focus to the new tab. This interrupts the user's workflow, especially when they want to queue up multiple tabs for later viewing while continuing to read the current page.

### Solution
The new "New Tab Background" checkbox in the Tab Behavior settings enables users to:
- Open new tabs without losing focus on the current tab
- Queue multiple tabs for later viewing
- Maintain reading flow without interruption

This feature enhances productivity by allowing uninterrupted browsing while preparing additional tabs in the background.

## Checklist

- [x] Revertable