### PR TITLE
リリース workflow を Chrome Web Store API v2 に切り替える

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     
     steps:
       - name: Checkout code
@@ -63,6 +64,77 @@ jobs:
           ZIP_FILE="dist/tab-position-options-fork-${{ env.VERSION }}-chrome.zip"
           echo "ZIP_FILE=$ZIP_FILE" >> $GITHUB_ENV
       
+      - name: Authenticate to Google Cloud
+        id: google_auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/chromewebstore
+          create_credentials_file: false
+          export_environment_variables: false
+
+      - name: Upload to Chrome Web Store (Draft)
+        env:
+          ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+        run: |
+          ITEM_NAME="publishers/${CHROME_PUBLISHER_ID}/items/${CHROME_EXTENSION_ID}"
+          UPLOAD_ENDPOINT="https://chromewebstore.googleapis.com/upload/v2/${ITEM_NAME}:upload"
+          STATUS_ENDPOINT="https://chromewebstore.googleapis.com/v2/${ITEM_NAME}:fetchStatus"
+          UPLOAD_RESPONSE_FILE=$(mktemp)
+
+          curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            -X POST \
+            -T "${ZIP_FILE}" \
+            "${UPLOAD_ENDPOINT}" \
+            -o "${UPLOAD_RESPONSE_FILE}"
+
+          cat "${UPLOAD_RESPONSE_FILE}"
+
+          UPLOAD_STATE=$(node -e "const fs = require('node:fs'); const response = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(response.uploadState ?? '');" "${UPLOAD_RESPONSE_FILE}")
+
+          if [ "${UPLOAD_STATE}" = "SUCCEEDED" ]; then
+            exit 0
+          fi
+
+          if [ "${UPLOAD_STATE}" != "IN_PROGRESS" ]; then
+            echo "Unexpected upload state: ${UPLOAD_STATE}" >&2
+            exit 1
+          fi
+
+          for attempt in $(seq 1 12); do
+            sleep 5
+
+            STATUS_RESPONSE_FILE=$(mktemp)
+
+            curl --fail-with-body --silent --show-error \
+              -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+              "${STATUS_ENDPOINT}" \
+              -o "${STATUS_RESPONSE_FILE}"
+
+            cat "${STATUS_RESPONSE_FILE}"
+
+            LAST_ASYNC_UPLOAD_STATE=$(node -e "const fs = require('node:fs'); const response = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(response.lastAsyncUploadState ?? '');" "${STATUS_RESPONSE_FILE}")
+
+            if [ "${LAST_ASYNC_UPLOAD_STATE}" = "SUCCEEDED" ]; then
+              exit 0
+            fi
+
+            if [ "${LAST_ASYNC_UPLOAD_STATE}" = "IN_PROGRESS" ]; then
+              continue
+            fi
+
+            echo "Unexpected async upload state: ${LAST_ASYNC_UPLOAD_STATE}" >&2
+            exit 1
+          done
+
+          echo "Timed out waiting for Chrome Web Store draft upload to finish." >&2
+          exit 1
+
       - name: Create Release
         id: create_release
         uses: ncipollo/release-action@v1
@@ -90,16 +162,6 @@ jobs:
           draft: false
           prerelease: false
           artifacts: ${{ env.ZIP_FILE }}
-      
-      - name: Upload to Chrome Web Store (Draft)
-        uses: mnao305/chrome-extension-upload@v5.0.0
-        with:
-          file-path: ${{ env.ZIP_FILE }}
-          extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
-          client-id: ${{ secrets.CHROME_CLIENT_ID }}
-          client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
-          refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}
-          publish: false  # 下書きとして保存
       
       - name: Summary
         run: |


### PR DESCRIPTION
## 関連URL

- https://github.com/proshunsuke/tab-position-options-fork/actions/runs/23107180647/job/67118359908
- https://developer.chrome.com/docs/webstore/service-accounts
- https://developer.chrome.com/docs/webstore/using-api

## 背景・目的

- 0.2.0 の release workflow は GitHub Release 作成までは成功したが、Chrome Web Store へのドラフトアップロードだけが失敗した
- 既存の `mnao305/chrome-extension-upload@v5.0.0` は refresh token 前提で、失敗時の詳細も取りづらく、Node 20 非推奨の警告も出ていた
- 今回必要なのは公開申請ではなくドラフトアップロードまでなので、Chrome Web Store API v2 を直接呼ぶ構成へ切り替えて、認証と失敗要因を明確にしたい

## 概要

- `mnao305/chrome-extension-upload@v5.0.0` を削除し、`google-github-actions/auth@v3` + Chrome Web Store API v2 の直接呼び出しへ置き換えた
- workflow 権限に `id-token: write` を追加し、`GCP_WORKLOAD_IDENTITY_PROVIDER` と `GCP_SERVICE_ACCOUNT_EMAIL` を使う WIF ベースの短命 access token で認証するようにした
- ドラフトアップロードは `upload` エンドポイントに ZIP を送る構成にし、`fetchStatus` をポーリングして非同期処理の完了まで待つようにした
- GitHub Release の作成順をドラフトアップロード成功後に移動し、ストア反映に失敗したリリースだけが残る状態を避けた
- 新しく `CHROME_PUBLISHER_ID` を必須にし、従来の `CHROME_CLIENT_ID` / `CHROME_CLIENT_SECRET` / `CHROME_REFRESH_TOKEN` には依存しない構成へ切り替えた

## チェック項目

- [x] Revert可能
- [x] npm run lint:check
- [x] GitHub Actions の release workflow 実行確認（WIF と Chrome Web Store 側設定の投入後に確認）
