### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.1
+- Fixed new tab positioning and tab closing behavior using stale session state after a Service Worker restart
+
 ## 0.2.0
 - Fixed tab closing behavior on Chrome 146 to keep the configured activation order working reliably
 - Updated the extension to work with the latest development toolchain and browser support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tab-position-options-fork",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tab-position-options-fork",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tab-position-options-fork",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Chrome extension to control where new tabs are opened",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Related URL

- https://github.com/proshunsuke/tab-position-options-fork/pull/49

## Background / Purpose

- Prepare the 0.2.1 release for the fixes already merged into main
- Publish the Service Worker restart stale session state fix as a release

## Overview

- Bump the extension version from 0.2.0 to 0.2.1
- Update CHANGELOG.md with the user-facing release note for the Service Worker restart stale-session fix

## Testing

- [x] npm install
- [x] npm run typecheck
- [x] npm run lint:check
- [x] npm run build
- [x] npm run test:e2e

## Technical Details

- Sync the release version in package.json and package-lock.json
- Base the 0.2.1 changelog entry on the merged scope of PR #49

## Checklist

- [x] Revert possible